### PR TITLE
Fix build errors and warnings

### DIFF
--- a/module/src/main/cpp/binder_interceptor.h
+++ b/module/src/main/cpp/binder_interceptor.h
@@ -1,0 +1,53 @@
+#ifndef BINDER_INTERCEPTOR_H
+#define BINDER_INTERCEPTOR_H
+
+#include <utils/RefBase.h>
+#include <binder/Parcel.h>
+#include <binder/IBinder.h>
+#include <binder/Binder.h>
+#include <utils/StrongPointer.h>
+#include <map>
+#include <shared_mutex>
+
+// Using android namespace for convenience if many types from it are used
+using namespace android;
+
+class BinderInterceptor : public BBinder {
+public:
+    sp<IBinder> gPropertyServiceBinder = nullptr;
+
+    bool handleIntercept(sp<BBinder> target, uint32_t code, const Parcel &data, Parcel *reply,
+                         uint32_t flags, status_t &result);
+    bool needIntercept(const wp<BBinder>& target);
+
+    status_t onTransact(uint32_t code, const android::Parcel &data, android::Parcel *reply,
+                        uint32_t flags) override;
+
+private:
+    enum {
+        REGISTER_INTERCEPTOR = 1,
+        UNREGISTER_INTERCEPTOR = 2,
+        REGISTER_PROPERTY_SERVICE = 3
+    };
+    enum { // These were likely intended to be scoped to functions or private
+        PRE_TRANSACT = 1,
+        POST_TRANSACT
+    };
+    enum { // These were likely intended to be scoped to functions or private
+        SKIP = 1,
+        CONTINUE,
+        OVERRIDE_REPLY,
+        OVERRIDE_DATA
+    };
+    struct InterceptItem {
+        wp<IBinder> target{};
+        sp<IBinder> interceptor;
+    };
+    using RwLock = std::shared_mutex;
+    using WriteGuard = std::unique_lock<RwLock>;
+    using ReadGuard = std::shared_lock<RwLock>;
+    RwLock lock;
+    std::map<wp<IBinder>, InterceptItem> items{};
+};
+
+#endif // BINDER_INTERCEPTOR_H

--- a/module/src/main/cpp/elf_util/elf_util.cpp
+++ b/module/src/main/cpp/elf_util/elf_util.cpp
@@ -190,11 +190,11 @@ const std::string ElfImg::findSymbolNameForAddr(ElfW(Addr) addr) const {
                 auto off = symtab_start[i].st_value;
                 auto len = symtab_start[i].st_size;
                 if (off <= addr_off && addr_off < off + len) {
-                    LOGD("found in symtab sym %p name %s", off,
+                    LOGD("found in symtab sym %p name %s", (void*)off,
                          st_name);
                     char buf[1024];
-                    snprintf(buf, sizeof(buf), "%s (0x%lx)+0x%lx/(0x%lx) from symtab %d", st_name,
-                             off, addr_off - off, len, i);
+                    snprintf(buf, sizeof(buf), "%s (0x%llx)+0x%llx/(0x%llx) from symtab %llu", st_name,
+                             (unsigned long long)off, (unsigned long long)(addr_off - off), (unsigned long long)len, (unsigned long long)i);
                     return buf;
                 }
             }
@@ -210,11 +210,11 @@ const std::string ElfImg::findSymbolNameForAddr(ElfW(Addr) addr) const {
                 auto off = dynsym_start[i].st_value;
                 auto len = dynsym_start[i].st_size;
                 if (off <= addr_off && addr_off < off + len) {
-                    LOGD("found in dynsym sym %p name %s", off,
+                    LOGD("found in dynsym sym %p name %s", (void*)off,
                          st_name);
                     char buf[1024];
-                    snprintf(buf, sizeof(buf), "%s (0x%lx)+0x%lx/(0x%lx) from dynsym %d", st_name,
-                             off, addr_off - off, len, i);
+                    snprintf(buf, sizeof(buf), "%s (0x%llx)+0x%llx/(0x%llx) from dynsym %llu", st_name,
+                             (unsigned long long)off, (unsigned long long)(addr_off - off), (unsigned long long)len, (unsigned long long)i);
                     return buf;
                 }
             }

--- a/module/src/main/cpp/inject/utils.cpp
+++ b/module/src/main/cpp/inject/utils.cpp
@@ -256,7 +256,7 @@ bool remote_pre_call(int pid, struct user_regs_struct &regs, uintptr_t func_addr
                      std::vector<uintptr_t> &args) {
     align_stack(regs);
     LOGV("calling remote function %" PRIxPTR " args %zu", func_addr, args.size());
-    for (auto &a: args) {
+    for (auto &[[maybe_unused]] a : args) {
         LOGV("arg %p", (void *) a);
     }
 #if defined(__x86_64__)


### PR DESCRIPTION
This commit addresses several build issues:

1.  **BinderInterceptor Incomplete Type:**
    *   Moved the `BinderInterceptor` class definition from
        `binder_interceptor.cpp` to a new header file
        `binder_interceptor.h`.
    *   Included `binder_interceptor.h` in `binder_interceptor.cpp`.
    *   Made `gPropertyServiceBinder`, `handleIntercept`, and
        `needIntercept` members/methods public to allow access
        from other parts of the code.

2.  **Parcel API Errors:**
    *   Replaced `writeInterfaceToken` with `writeString16` for writing
        the interface token in `binder_interceptor.cpp`.
    *   Replaced `readCString` with `readString16` followed by a
        conversion to `String8` to get a `const char*`, ensuring
        `nullptr` is handled correctly for empty strings.
    *   Added `#include <utils/String8.h>` for `String8` usage.

3.  **Format Specifier Warnings (`elf_util.cpp`):**
    *   Corrected `snprintf` format specifiers to use `%llx` for
        `Elf64_Addr` and `Elf64_Xword` types, and `%llu` for
        `Elf64_Off` types.
    *   Added explicit C-style casts to `(unsigned long long)` for
        arguments in `snprintf` to ensure type safety with the
        new format specifiers.

4.  **Unused Variable Warning (`inject/utils.cpp`):**
    *   Added `[[maybe_unused]]` attribute to the unused loop
        variable `a` to suppress the compiler warning.

These changes should resolve the reported build failures and warnings.