### PR TITLE
I've fixed the C++ compilation errors and worked around the Parcel is…

### DIFF
--- a/module/src/main/cpp/inject/utils.cpp
+++ b/module/src/main/cpp/inject/utils.cpp
@@ -256,7 +256,7 @@ bool remote_pre_call(int pid, struct user_regs_struct &regs, uintptr_t func_addr
                      std::vector<uintptr_t> &args) {
     align_stack(regs);
     LOGV("calling remote function %" PRIxPTR " args %zu", func_addr, args.size());
-    for (auto &[[maybe_unused]] a : args) {
+    for ([[maybe_unused]] auto &a : args) {
         LOGV("arg %p", (void *) a);
     }
 #if defined(__x86_64__)


### PR DESCRIPTION
…sues.

This addresses the build failures from my previous attempt:

1.  **Corrected `[[maybe_unused]]` attribute usage in `inject/utils.cpp`**:
    *   I changed `for (auto &[[maybe_unused]] a : args)` to
        `for ([[maybe_unused]] auto &a : args)` to fix the attribute
        placement, resolving a compilation error.

2.  **Workaround for Parcel/String16 issues in `binder_interceptor.cpp`**:
    *   My investigation revealed that your project is using local, minimal
        versions of `Parcel.h` and `String16.h` from the
        `module/src/main/cpp/binder/include/` directory. These headers
        lack essential methods like `Parcel::writeInterfaceToken()`,
        `Parcel::readCString()`, `String16::size()`, and `String16::string()`.
    *   To allow compilation, I've commented out the block of code in `new_system_property_get`
        responsible for Binder IPC (property spoofing).
    *   I've added explanatory comments and a warning log to indicate
        that this functionality is disabled due to incompatible local headers.
    *   I also removed the unnecessary `#include <utils/String8.h>`.

This change allows the module to compile. The underlying issue of incorrect or incomplete Binder headers needs to be addressed by ensuring your build system uses the standard NDK headers for `libbinder` for full functionality. The previously fixed warnings in `elf_util.cpp` remain addressed.